### PR TITLE
editアクションのpropsを変更

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -20,14 +20,24 @@ class TasksController < ApplicationController
   end
 
   def edit
-    render inertia: "Tasks/Edit", props: {
-      task: {
-        id: @task.id,
-        name: @task.name,
-        memo: @task.memo,
-        deadline_at: @task.deadline_at.strftime("%Y-%m-%dT%T")
+    if @task.deadline_at.nil?
+      render inertia: "Tasks/Edit", props: {
+          task: {
+            id: @task.id,
+            name: @task.name,
+            memo: @task.memo
+          }
+        }
+    else
+      render inertia: "Tasks/Edit", props: {
+        task: {
+          id: @task.id,
+          name: @task.name,
+          memo: @task.memo,
+          deadline_at: @task.deadline_at.strftime("%Y-%m-%dT%T")
+        }
       }
-    }
+    end
   end
 
   def update


### PR DESCRIPTION
## 概要
締切日なしで登録されたタスクを編集しようとした時、railsがdatetime-localに対応する`strftime("%Y-%m-%dT%T")`メソッドが、nilに対応していないエラーを出しました。
<img width="720" height="491" alt="スクリーンショット 2026-01-08 11 47 29" src="https://github.com/user-attachments/assets/e16138bb-ffd0-4a52-a266-c96574c2aac8" />

締切日を加工するstrftimeメソッドを使う場合と使わない場合とで、条件分岐させました。
## やったこと
editアクション内で、propsを2つ作成しました。条件分岐にし、締切日がある場合は渡す、ない場合は渡さない(strftimeメソッドを呼ばない)ことにしました。

## To Reviewers
nilが入らないような形での修正か、nilガードでデフォルト値を決めておく形も決めましたが、当初の予定では締切日はない場合もあるということで始めたため、締切日がない場合はpropsとして渡さない手法を取りました。

## テスト
- [x] 締切日なしでの新規作成、編集も行えることを確認しました。
